### PR TITLE
Add account flag to ignore waiting for DNS propagation

### DIFF
--- a/acme/account.go
+++ b/acme/account.go
@@ -46,14 +46,6 @@ func (a *account) getClient() (*lego.Client, error) {
 	return lego.NewClient(config)
 }
 
-func getOrDefault(dict map[string]interface{}, key string, defaultValue interface{}) interface{} {
-	if value, found := dict[key]; found {
-		return value
-	} else {
-		return defaultValue
-	}
-}
-
 func getAccount(ctx context.Context, storage logical.Storage, path string) (*account, error) {
 	storageEntry, err := storage.Get(ctx, path)
 	if err != nil {
@@ -73,7 +65,7 @@ func getAccount(ctx context.Context, storage logical.Storage, path string) (*acc
 		return nil, err
 	}
 
-	return &account{
+	a := &account{
 		Email:   d["contact"].(string),
 		Key:     privateKey,
 		KeyType: d["key_type"].(string),
@@ -85,8 +77,13 @@ func getAccount(ctx context.Context, storage logical.Storage, path string) (*acc
 		TermsOfServiceAgreed: d["terms_of_service_agreed"].(bool),
 		EnableHTTP01:         d["enable_http_01"].(bool),
 		EnableTLSALPN01:      d["enable_tls_alpn_01"].(bool),
-		IgnoreDNSPropagation: getOrDefault(d, "ignore_dns_propagation", false).(bool),
-	}, nil
+	}
+
+	if ignoreDNSPropagation, ok := d["ignore_dns_propagation"]; ok {
+		a.IgnoreDNSPropagation = ignoreDNSPropagation.(bool)
+	}
+
+	return a, nil
 }
 
 func (a *account) save(ctx context.Context, storage logical.Storage, path string, serverURL string) error {

--- a/acme/account.go
+++ b/acme/account.go
@@ -21,6 +21,7 @@ type account struct {
 	EnableHTTP01         bool
 	EnableTLSALPN01      bool
 	TermsOfServiceAgreed bool
+	IgnoreDNSPropagation bool
 }
 
 // GetEmail returns the Email of the user
@@ -43,6 +44,14 @@ func (a *account) getClient() (*lego.Client, error) {
 	config.CADirURL = a.ServerURL
 
 	return lego.NewClient(config)
+}
+
+func getOrDefault(dict map[string]interface{}, key string, defaultValue interface{}) interface{} {
+	if value, found := dict[key]; found {
+		return value
+	} else {
+		return defaultValue
+	}
 }
 
 func getAccount(ctx context.Context, storage logical.Storage, path string) (*account, error) {
@@ -76,6 +85,7 @@ func getAccount(ctx context.Context, storage logical.Storage, path string) (*acc
 		TermsOfServiceAgreed: d["terms_of_service_agreed"].(bool),
 		EnableHTTP01:         d["enable_http_01"].(bool),
 		EnableTLSALPN01:      d["enable_tls_alpn_01"].(bool),
+		IgnoreDNSPropagation: getOrDefault(d, "ignore_dns_propagation", false).(bool),
 	}, nil
 }
 
@@ -96,6 +106,7 @@ func (a *account) save(ctx context.Context, storage logical.Storage, path string
 		"provider":                a.Provider,
 		"enable_http_01":          a.EnableHTTP01,
 		"enable_tls_alpn_01":      a.EnableTLSALPN01,
+		"ignore_dns_propagation":  a.IgnoreDNSPropagation,
 	})
 	if err != nil {
 		return err

--- a/acme/path_accounts.go
+++ b/acme/path_accounts.go
@@ -52,6 +52,10 @@ func pathAccounts(b *backend) *framework.Path {
 			"enable_tls_alpn_01": &framework.FieldSchema{
 				Type: framework.TypeBool,
 			},
+			"ignore_dns_propagation": &framework.FieldSchema{
+				Type:    framework.TypeBool,
+				Default: false,
+			},
 			"contact": &framework.FieldSchema{
 				Type:     framework.TypeString,
 				Required: true,
@@ -96,6 +100,7 @@ func (b *backend) accountCreate(ctx context.Context, req *logical.Request, data 
 	provider := data.Get("provider").(string)
 	enableHTTP01 := data.Get("enable_http_01").(bool)
 	enableTLSALPN01 := data.Get("enable_tls_alpn_01").(bool)
+	ignoreDNSPropagation := data.Get("ignore_dns_propagation").(bool)
 
 	keyType, err := getKeyType(data.Get("key_type").(string))
 	if err != nil {
@@ -117,6 +122,7 @@ func (b *backend) accountCreate(ctx context.Context, req *logical.Request, data 
 		EnableHTTP01:         enableHTTP01,
 		EnableTLSALPN01:      enableTLSALPN01,
 		TermsOfServiceAgreed: termsOfServiceAgreed,
+		IgnoreDNSPropagation: ignoreDNSPropagation,
 	}
 
 	client, err := user.getClient()
@@ -164,6 +170,7 @@ func (b *backend) accountRead(ctx context.Context, req *logical.Request, data *f
 			"provider":                a.Provider,
 			"enable_http_01":          a.EnableHTTP01,
 			"enable_tls_alpn_01":      a.EnableTLSALPN01,
+			"ignore_dns_propagation":  a.IgnoreDNSPropagation,
 		},
 	}, nil
 }

--- a/acme/path_accounts_test.go
+++ b/acme/path_accounts_test.go
@@ -24,6 +24,7 @@ func TestAccounts(t *testing.T) {
 		"key_type":                "EC256",
 		"enable_http_01":          false,
 		"enable_tls_alpn_01":      false,
+		"ignore_dns_propagation":  false,
 	}
 
 	testCases := []struct {

--- a/acme/path_certs.go
+++ b/acme/path_certs.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/go-acme/lego/v3/certcrypto"
 	"github.com/go-acme/lego/v3/certificate"
+	"github.com/go-acme/lego/v3/challenge/dns01"
 	"github.com/go-acme/lego/v3/lego"
 	"github.com/go-acme/lego/v3/providers/dns"
 	"github.com/hashicorp/vault/sdk/framework"
@@ -184,7 +185,8 @@ func (b *backend) setupChallengeProviders(ctx context.Context, client *lego.Clie
 		if err != nil {
 			return err
 		}
-		err = client.Challenge.SetDNS01Provider(provider)
+		err = client.Challenge.SetDNS01Provider(provider,
+			dns01.CondOption(a.IgnoreDNSPropagation, dns01.DisableCompletePropagationRequirement()))
 		if err != nil {
 			return err
 		}

--- a/website/source/api/secret/acme/index.html.md
+++ b/website/source/api/secret/acme/index.html.md
@@ -50,7 +50,7 @@ This endpoint register an ACME account with the provided ACME CA.
 - `provider` `(string: <optional>)` - Which DNS provider to use to resolve the DNS challenge. Setting this parameter will activate the DNS-01 challenge.
 - `enable_http_01` `(bool: false)` - Whether to activate the HTTP-01 challenge.
 - `enable_tls_alpn_01` `(bool: false)` - Whether to activate the TLS-ALPN-01 challenge.
-- `ignore_dns_propagation` `(bool: false)` - Do not wait until the DNS updates have been propagated to all DNS servers. Only relevent for DNS01 challenges.
+- `ignore_dns_propagation` `(bool: false)` - Do not wait until the DNS updates have been propagated to all DNS servers. Only relevent for DNS-01 challenges.
 
 ## Read ACME account
 

--- a/website/source/api/secret/acme/index.html.md
+++ b/website/source/api/secret/acme/index.html.md
@@ -50,6 +50,7 @@ This endpoint register an ACME account with the provided ACME CA.
 - `provider` `(string: <optional>)` - Which DNS provider to use to resolve the DNS challenge. Setting this parameter will activate the DNS-01 challenge.
 - `enable_http_01` `(bool: false)` - Whether to activate the HTTP-01 challenge.
 - `enable_tls_alpn_01` `(bool: false)` - Whether to activate the TLS-ALPN-01 challenge.
+- `ignore_dns_propagation` `(bool: false)` - Do not wait until the DNS updates have been propagated to all DNS servers. Only relevent for DNS01 challenges.
 
 ## Read ACME account
 


### PR DESCRIPTION
Provide a way to let lego ignore the check for DNS propagation. The
default remains `false` (default value of library): wait until the
DNS changes have been propagated to all authoritative DNS servers.
Existing vault accounts should continue to work (new flag will be set to
`false` if it does not exists).

This option might be helpful/required for specific setups/situation
where this does not work correctly (like specific split-horizon setups
etc).

The `ignore_dns_propagation` option behaves as the underlaying
`--dns.disable-cp` command line LEGO flag.