### PR TITLE
Simplify running the tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.16
+    - name: Set up Go 1.18
       uses: actions/setup-go@v1
       with:
-        go-version: 1.16
+        go-version: 1.18
       id: go
 
     - name: Check out code into the Go module directory
@@ -23,30 +23,16 @@ jobs:
         GO111MODULE=off go get -u github.com/letsencrypt/pebble/...
 
     - name: Run unit tests
-      env:
-        PEBBLE_VA_NOSLEEP: 1
       run: |
         export PATH=$PATH:$(go env GOPATH)/bin
-        pebble -dnsserver 127.0.0.1:8053 &
-        pebble-challtestsrv -http01 "" -https01 "" -tlsalpn01 "" &
         make test
-        kill %1 %2
 
     - name: Run acceptance tests
-      env:
-        PEBBLE_VA_NOSLEEP: 1
-        LEGO_TEST_NAMESERVER: 127.0.0.1:8053
-        EXEC_PROPAGATION_TIMEOUT: 5
       run: |
-        export LEGO_CA_CERTIFICATES=$PWD/test/certs/pebble.minica.pem
-        export EXEC_PATH=$PWD/test/test_dns.sh
-        export PATH=$PATH:$(go env GOPATH)/bin
         curl -sLo vault.zip https://releases.hashicorp.com/vault/1.3.2/vault_1.3.2_linux_amd64.zip
         unzip vault.zip
         sudo mv vault /usr/local/bin/vault
-        pebble -dnsserver 127.0.0.1:8053 &
-        pebble-challtestsrv -http01 "" -https01 "" -tlsalpn01 "" &
-        vault server -dev -config ./test/vault.hcl -dev-root-token-id foo &
+        export PATH=$PATH:$(go env GOPATH)/bin
         make testacc
 
     - name: Build all binaries

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,10 +6,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.16
+    - name: Set up Go 1.18
       uses: actions/setup-go@v1
       with:
-        go-version: 1.16
+        go-version: 1.18
       id: go
 
     - name: Check out code into the Go module directory
@@ -20,28 +20,13 @@ jobs:
         GO111MODULE=off go get -u github.com/letsencrypt/pebble/...
 
     - name: Run unit tests
-      env:
-        PEBBLE_VA_NOSLEEP: 1
       run: |
         export PATH=$PATH:$(go env GOPATH)/bin
-        pebble -dnsserver 127.0.0.1:8053 &
-        pebble-challtestsrv -http01 "" -https01 "" -tlsalpn01 "" &
         make test
-        kill %1 %2
 
     - name: Run acceptance tests
-      env:
-        PEBBLE_VA_NOSLEEP: 1
-        LEGO_TEST_NAMESERVER: 127.0.0.1:8053
-        EXEC_PROPAGATION_TIMEOUT: 5
       run: |
-        export LEGO_CA_CERTIFICATES=$PWD/test/certs/pebble.minica.pem
-        export EXEC_PATH=$PWD/test/test_dns.sh
-        export PATH=$PATH:$(go env GOPATH)/bin
         curl -sLo vault.zip https://releases.hashicorp.com/vault/1.3.2/vault_1.3.2_linux_amd64.zip
         unzip vault.zip
         sudo mv vault /usr/local/bin/vault
-        pebble -dnsserver 127.0.0.1:8053 &
-        pebble-challtestsrv -http01 "" -https01 "" -tlsalpn01 "" &
-        vault server -dev -config ./test/vault.hcl -dev-root-token-id foo &
         make testacc

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,4 +29,5 @@ jobs:
         curl -sLo vault.zip https://releases.hashicorp.com/vault/1.3.2/vault_1.3.2_linux_amd64.zip
         unzip vault.zip
         sudo mv vault /usr/local/bin/vault
+        export PATH=$PATH:$(go env GOPATH)/bin
         make testacc

--- a/README.md
+++ b/README.md
@@ -34,25 +34,20 @@ you can mount the plugin like any other: `vault secrets enable -path acme -plugi
 
 ## Tests
 
-Unit tests are run against [Pebble](https://github.com/letsencrypt/pebble):
+The unit tests will use the `pebble` ACME test server and `pebble-challtestsrv`.
+They can be downloaded at https://github.com/letsencrypt/pebble and must be
+present in `$PATH`.
+
+The unit tests can be run with:
 
 ```bash
-$ export PEBBLE_VA_NOSLEEP=1
-$ pebble -dnsserver 127.0.0.1:8053 &
-$ pebble-challtestsrv -http01 "" -https01 "" -tlsalpn01 "" &
 $ make test
 ```
 
-and acceptance tests both Pebble and a running Vault server:
+The acceptance tests needs Vault in addition to `pebble` and `pebble-challtestsrv`.
+
+When `vault` is present in `$PATH` the acceptance tests can be run with:
 
 ```bash
-$ export LEGO_TEST_NAMESERVER=127.0.0.1:8053
-$ export LEGO_CA_CERTIFICATES=$PWD/test/certs/pebble.minica.pem
-$ export PEBBLE_VA_NOSLEEP=1
-$ export EXEC_PROPAGATION_TIMEOUT=5
-$ export EXEC_PATH=$PWD/test/test_dns.sh
-$ pebble -dnsserver 127.0.0.1:8053 &
-$ pebble-challtestsrv -http01 "" -https01 "" -tlsalpn01 "" &
-$ vault server -dev -config ./test/vault.hcl -dev-root-token-id foo &
 $ make testacc
 ```

--- a/acme/path_accounts_test.go
+++ b/acme/path_accounts_test.go
@@ -11,14 +11,14 @@ func TestAccounts(t *testing.T) {
 	config, b := getTestConfig(t)
 
 	data := map[string]interface{}{
-		"server_url":              serverURL,
+		"server_url":              "https://localhost:14000/dir",
 		"contact":                 "remi@lenstra.fr",
 		"terms_of_service_agreed": true,
 		"provider":                "exec",
 	}
 	expected := map[string]interface{}{
 		"contact":                 "remi@lenstra.fr",
-		"server_url":              serverURL,
+		"server_url":              "https://localhost:14000/dir",
 		"terms_of_service_agreed": true,
 		"provider":                "exec",
 		"provider_configuration":  map[string]string{},
@@ -108,7 +108,7 @@ func TestUpdateAccount(t *testing.T) {
 		Path:      "accounts/lenstra",
 		Storage:   config.StorageView,
 		Data: map[string]interface{}{
-			"server_url":              serverURL,
+			"server_url":              "https://localhost:14000/dir",
 			"contact":                 "rem@lenstra.fr",
 			"terms_of_service_agreed": true,
 			"provider":                "exec",
@@ -130,7 +130,7 @@ func TestDeleteAccount(t *testing.T) {
 		Path:      "accounts/lenstra",
 		Storage:   config.StorageView,
 		Data: map[string]interface{}{
-			"server_url":              serverURL,
+			"server_url":              "https://localhost:14000/dir",
 			"contact":                 "remi@lenstra.fr",
 			"terms_of_service_agreed": true,
 			"provider":                "exec",
@@ -162,7 +162,7 @@ func TestListAccounts(t *testing.T) {
 		Path:      "accounts/lenstra",
 		Storage:   config.StorageView,
 		Data: map[string]interface{}{
-			"server_url":              serverURL,
+			"server_url":              "https://localhost:14000/dir",
 			"contact":                 "remi@lenstra.fr",
 			"terms_of_service_agreed": true,
 			"provider":                "exec",

--- a/acme/path_certs_test.go
+++ b/acme/path_certs_test.go
@@ -39,7 +39,7 @@ func TestExplicitProviderConfiguration(t *testing.T) {
 		Path:      "accounts/lenstra",
 		Storage:   config.StorageView,
 		Data: map[string]interface{}{
-			"server_url":              serverURL,
+			"server_url":              "https://localhost:14000/dir",
 			"contact":                 "remi@lenstra.fr",
 			"terms_of_service_agreed": true,
 			"provider":                "exec",
@@ -201,14 +201,14 @@ func checkCertificate(t *testing.T, resp *logical.Response) {
 	if err == nil {
 		t.Fatal("Was expecting error but got none.")
 	}
-	if err.Error() != `Get "https://example.com": x509: “sentry.lenstra.fr” certificate is not standards compliant` {
+	if err.Error() != "Get \"https://example.com\": x509: certificate is valid for sentry.lenstra.fr, grafana.lenstra.fr, not example.com" && err.Error() != `Get "https://example.com": x509: “sentry.lenstra.fr” certificate is not standards compliant` {
 		t.Fatalf("Got wrong error: %s", err.Error())
 	}
 
 	HTTPResp, err := http.Get("https://sentry.lenstra.fr")
 	if err != nil {
 		// This is expected as the intermediate test cert may not be installed
-		if err.Error() != `Get "https://sentry.lenstra.fr": x509: “sentry.lenstra.fr” certificate is not standards compliant` {
+		if err.Error() != "Get \"https://sentry.lenstra.fr\": x509: certificate signed by unknown authority" && err.Error() != `Get "https://sentry.lenstra.fr": x509: “sentry.lenstra.fr” certificate is not standards compliant` {
 			t.Fatalf("%s", err.Error())
 		}
 	}

--- a/acme/path_roles_test.go
+++ b/acme/path_roles_test.go
@@ -23,7 +23,7 @@ func TestListRoles(t *testing.T) {
 		Path:      "accounts/lenstra",
 		Storage:   config.StorageView,
 		Data: map[string]interface{}{
-			"server_url":              serverURL,
+			"server_url":              "https://localhost:14000/dir",
 			"contact":                 "remi@lenstra.fr",
 			"terms_of_service_agreed": true,
 			"provider":                "exec",

--- a/test/config/pebble-config.json
+++ b/test/config/pebble-config.json
@@ -2,8 +2,8 @@
     "pebble": {
         "listenAddress": "0.0.0.0:14000",
         "managementListenAddress": "0.0.0.0:15000",
-        "certificate": "test/certs/localhost/cert.pem",
-        "privateKey": "test/certs/localhost/key.pem",
+        "certificate": "../test/certs/localhost/cert.pem",
+        "privateKey": "../test/certs/localhost/key.pem",
         "httpPort": 5002,
         "tlsPort": 5001,
         "ocspResponderURL": ""

--- a/test/vault.hcl
+++ b/test/vault.hcl
@@ -1,1 +1,1 @@
-plugin_directory = "./build"
+plugin_directory = "./../build"


### PR DESCRIPTION
All external programs needed by the tests are now started and stopped
automatically which should make local development a bit easier.